### PR TITLE
14 prop decorator

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+// doesn't work with es6 module import
 
 interface ITodo {
   userId: number;


### PR DESCRIPTION
Doesn't work in strict mode.
tsc adds `'use strict';` if using es6 modules or with `alwaysStrict: true` compiler option and it breaks execution throwing error `TypeError: Cannot read property '_$$todos$$_' of undefined`.